### PR TITLE
Rebuild the syntax with regions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 
 ## Links
 
-* http://www.sublimetext.com/docs/3/syntax.html
-* https://www.sublimetext.com/docs/3/scope_naming.html
+* https://www.sublimetext.com/docs/syntax.html
+* https://www.sublimetext.com/docs/scope_naming.html

--- a/demo/email.eml
+++ b/demo/email.eml
@@ -18,9 +18,9 @@ Content-Type: text/html
 <html>
 <head>
   <title>Airmail 1.5 for iOS</title>
-  <style type="text/css">* {
+  <style type="text/css">
   * {
-  font-family:Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: Roboto, "Helvetica Neue", Helvetica, Arial, sans-serif;
   }
   </style>
 </head>

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -81,7 +81,7 @@ contexts:
 
   generic-header-kvp:
     # https://en.wikipedia.org/wiki/Email#Message_header
-    - match: ^((?i:(x-)?[a-z0-9-]+))(:)
+    - match: ^((?i:(x-)?[a-z0-9-]+))\b(:)
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: variable.annotation.eml
@@ -169,25 +169,25 @@ contexts:
   expect-body-instructions:
     - match: ^\n$
       set: body-content-default
-    - match: ^((?i:Content-Type))(:)\s(image/\w+)\b
+    - match: ^((?i:Content-Type))(:)\s*(image/\w+)\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
         3: entity.name.enum.eml
       set: [expect-body-instructions-image, header-value]
-    - match: ^((?i:Content-Type))(:)\s(message/[\w-]+)\b
+    - match: ^((?i:Content-Type))(:)\s*(message/[\w-]+)\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
         3: entity.name.enum.eml
       set: [expect-body-instructions-headers, header-value]
-    - match: ^((?i:Content-Type))(:)\s(text/(?:watch-)?html)\b
+    - match: ^((?i:Content-Type))(:)\s*(text/(?:watch-)?html)\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
         3: entity.name.enum.eml
       set: [expect-body-instructions-html-noencoding, header-value]
-    - match: ^((?i:Content-Transfer-Encoding))(:)\squoted-printable\b
+    - match: ^((?i:Content-Transfer-Encoding))(:)\s*quoted-printable\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
@@ -196,7 +196,7 @@ contexts:
     - include: generic-header-kvp
 
   become-expect-base64:
-    - match: ^((?i:Content-Transfer-Encoding))(:)\sbase64\b
+    - match: ^((?i:Content-Transfer-Encoding))(:)\s*base64\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
@@ -205,7 +205,7 @@ contexts:
   expect-body-instructions-base64:
     - match: ^\n$
       set: body-content-base64
-    - match: ^((?i:Content-Type))(:)\s(image/\w+)\b
+    - match: ^((?i:Content-Type))(:)\s*(image/\w+)\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
@@ -227,7 +227,7 @@ contexts:
     - match: ^\n$
       set: body-content-html
     - include: become-expect-base64
-    - match: ^((?i:Content-Transfer-Encoding))(:)\squoted-printable\b
+    - match: ^((?i:Content-Transfer-Encoding))(:)\s*quoted-printable\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -46,7 +46,9 @@ contexts:
     - meta_content_scope: meta.block.header.eml
     - match: ^(?=\r?\n)
       set: body-block
+    - include: headers
 
+  headers:
     # Special headers
     - match: ^((?i:From|To|Cc|Bcc|Date))(:)
       captures:
@@ -253,7 +255,7 @@ contexts:
   body-content-headers:
     - meta_content_scope: meta.region.body.email
     - include: pop-before-boundary
-    - include: generic-header-kvp
+    - include: headers
 
   body-content-image:
     - meta_content_scope: meta.region.body.email

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -145,7 +145,24 @@ contexts:
   expect-body-instructions:
     - match: ^\n$
       set: body-content
+    - match: ^((?i:Content-Type))(:)\s(image/\w+)\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+        3: entity.name.enum.eml
+      set: [expect-body-instructions-image, header-value]
     - include: generic-header-kvp
+
+  expect-body-instructions-image:
+    - match: ^\n$
+      set: body-content-image
+    - include: generic-header-kvp
+
+  body-content-image:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
+    - match: ^{{base64_string}}$\n?
+      scope: meta.block.base64.image.eml string.unquoted.eml
 
   body-content:
     - meta_content_scope: meta.region.body.email

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -237,6 +237,12 @@ contexts:
   expect-body-instructions-quoted-printable:
     - match: ^\n$
       set: body-content-quoted-printable
+    - match: ^((?i:Content-Type))(:)\s*(text/(?:watch-)?html)\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+        3: entity.name.enum.eml
+      set: [expect-body-instructions-html-quoted-printable, header-value]
     - include: generic-header-kvp
 
   expect-body-instructions-html-quoted-printable:

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -123,17 +123,17 @@ contexts:
         - include: mime-type
 
   mime-type:
-    - match: \b(?:text|application|multipart|message|image)/\b[a-z-]+\b
+    - match: \b(?:text|application|multipart|message|image)/\b[a-z\d-]+\b
       scope: entity.name.enum.eml
 
   body-block:
     - meta_content_scope: meta.block.body.eml
-    - match: ^--({{boundary_name}})--$
+    - match: ^--({{boundary_name}})--(?:\n|$)
       scope: punctuation.terminator.eml
       captures:
         1: variable.language.eml
     # Body with boundaries
-    - match: ^--({{boundary_name}})$
+    - match: ^--({{boundary_name}})(?:\n|$)
       scope: punctuation.separator.sequence.eml
       captures:
         1: variable.language.eml

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -63,12 +63,20 @@ contexts:
           pop: true
 
     # Security Headers
-    - match: ^((?:\S+-)?Signature|Authentication-Results|DomainKey-Signature|Received-SPF)(:)"
+    - match: |-
+        ^(?x:(
+          ARC-Seal|
+          (?:ARC-)?(?:Authentication-Results)|
+          ([xX]-)?(?:\w+-)*(?:DomainKey|DKIM|Message)-Signature|
+          Received-SPF
+        ))(:)
       captures:
         1: meta.mapping.key.header.eml support.function.eml
-        2: punctuation.separator.mapping.key-value.eml
+        2: variable.annotation.eml
+        3: punctuation.separator.mapping.key-value.eml
       push: header-value
 
+    # Generic headers
     - include: generic-header-kvp
 
   generic-header-kvp:

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -221,10 +221,66 @@ contexts:
 
   timestamps:
     # https://tools.ietf.org/html/rfc5322#section-3.3
-    - match: '{{day3}},.*[+-][0-9]{4}\s(?:.{4}\))?'
-      scope: constant.numeric.date-time.eml
-    - match: '\d{1,2} {{month3}}.*[+-][0-9]{4}\s(?:.{4}\))?'
-      scope: constant.numeric.date-time.eml
+    - match: \b{{day3}}(,)(?=\s\d{1,2}|$)
+      captures:
+        1: punctuation.separator.sequence.eml
+      set: maybe-timestamp-day
+    - match: \b(?=(?:[1-9]|[12]\d|3[01])(?:\s{{month3}}|$))
+      set: maybe-timestamp-day
+
+  maybe-timestamp-day:
+    - meta_scope: constant.numeric.date-time.eml
+    - match: \b(?:[1-9]|[12]\d|3[01])(?=\s{{month3}}|$)
+      set: in-timestamp-month
+    - match: (?=\S)
+      pop: true
+
+  in-timestamp-month:
+    - meta_scope: constant.numeric.date-time.eml
+    - match: \b{{month3}}\b
+      set: in-timestamp-year
+    - match: (?=\S)
+      pop: true
+
+  in-timestamp-year:
+    - meta_scope: constant.numeric.date-time.eml
+    - match: \b(?:19\d{2}|20\d{2})\b
+      set: in-timestamp-time-of-day
+    - match: (?=\S)
+      pop: true
+
+  in-timestamp-time-of-day:
+    - meta_scope: constant.numeric.date-time.eml
+    - match: |-
+        (?x:
+          (?:[01]\d|2[0-3])  # hour
+          (:)
+          (?:[0-5]\d)        # minute
+          (?:
+            (:)
+            (?:[0-5]\d)      # second (optional)
+            (?:
+              (\.)
+              \d{1,4}        # fractional second (not RFC5322)
+            )?
+          )?
+        )
+      captures:
+        1: punctuation.separator.sequence.eml
+        2: punctuation.separator.sequence.eml
+        3: punctuation.separator.decimal.eml
+      set: in-timestamp-zone
+    - match: (?=\S)
+      pop: true
+
+  in-timestamp-zone:
+    - meta_scope: constant.numeric.date-time.eml
+    - match: ([+-])(?:0\d{3}|1[0-2]\d{2})
+      captures:
+        1: keyword.operator.arithmetic.eml
+      pop: true
+    - match: (?=\S)
+      pop: true
 
   ip-addresses:
     - match: '(\[){{ipv4}}(\])'

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -252,15 +252,8 @@ contexts:
     - meta_content_scope: meta.region.body.email
     - include: pop-before-boundary
     - match: ''
-      push: scope:text.html.basic
-      with_prototype:
-        - match: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
-          pop: true
-        - match: \b=3[dD](?=['"])
-          scope: constant.character.escape.eml
-          push:
-            - scope:text.html.basic#tag-generic-attribute-value
-        - include: quoted-printable
+      embed: html-with-quoted-printable
+      escape: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
 
   body-content-quoted-printable:
     - meta_content_scope: meta.region.body.email
@@ -285,6 +278,17 @@ contexts:
     - meta_content_scope: meta.region.body.email
     - include: pop-before-boundary
     - include: base64-line
+
+  html-with-quoted-printable:
+    - match: ''
+      push: scope:text.html.basic
+      with_prototype:
+        # Unbreak QP version of `=` in attributes
+        - match: \b=3[dD](?=['"])
+          scope: constant.character.escape.eml punctuation.separator.key-value.html
+          push:
+            - scope:text.html.basic#tag-generic-attribute-value
+        - include: quoted-printable
 
   base64-line:
     # Content-Transfer-Encoding: base64
@@ -358,7 +362,8 @@ contexts:
       push: maybe-timestamp-day
 
   ignore-qp-newline-pop-nonws:
-    - match: =$
+    - match: =\n
+      scope: punctuation.separator.continuation.eml
     - match: (?=\S)
       pop: true
 

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -80,10 +80,24 @@ contexts:
         3: punctuation.separator.mapping.key-value.eml
       push: header-value
 
+  header-comment:
+    # https://tools.ietf.org/html/rfc5322#appendix-A.5
+    - match: \(
+      scope: punctuation.definition.comment.begin.eml
+      push:
+        - meta_scope: comment.block.eml
+        - match: \\[()]
+          scope: constant.character.escape.eml
+        - match: \)
+          scope: punctuation.definition.comment.end.eml
+          pop: true
+        - include: header-comment
+
   header-value:
     - meta_content_scope: meta.mapping.value.header.eml
     - match: ^(?=\S|$)
       pop: true
+    - include: header-comment
     - include: common
     - match: \b([a-zA-Z0-9-]+)\b(=)(?!\s|=)
       captures:
@@ -116,6 +130,8 @@ contexts:
       scope: punctuation.definition.string.begin.eml
       push:
         - meta_scope: string.quoted.double.eml
+        - match: \\"
+          scope: constant.character.escape.eml
         - match: '"'
           scope: punctuation.definition.string.end.eml
           pop: true

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -338,7 +338,7 @@ contexts:
       captures:
         1: punctuation.separator.sequence.eml
       push: maybe-timestamp-day
-    - match: \b(?=(?:[1-9]|[12]\d|3[01])(?:\s{{month3}}|\s?=?$))
+    - match: \b(?=(?:0?[1-9]|[12]\d|3[01])(?:\s{{month3}}|\s?=?$))
       push: maybe-timestamp-day
 
   ignore-qp-newline-pop-nonws:
@@ -348,7 +348,7 @@ contexts:
 
   maybe-timestamp-day:
     - meta_content_scope: constant.numeric.date-time.eml
-    - match: \b(?:[1-9]|[12]\d|3[01])(?=\s{{month3}}|\s?=?$)
+    - match: \b(?:0?[1-9]|[12]\d|3[01])(?=\s{{month3}}|\s?=?$)
       set: in-timestamp-month
     - include: ignore-qp-newline-pop-nonws
 

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -1,76 +1,279 @@
 %YAML 1.2
 ---
-
 name: Email
 file_extensions:
   - eml
   - msg
   - mbx
   - mboxz
-scope: source.eml
+scope: text.eml
+
+variables:
+  zero_to_255: (?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9][0-9])|(?:[1-9][0-9])|[0-9])
+  ipv4: \b(?:(?:{{zero_to_255}}\.){3}{{zero_to_255}})\b
+  ipv6: |-
+    (?xi:
+      (?:::(?:ffff(?::0{1,4}){0,1}:){0,1}{{ipv4}})          # ::255.255.255.255  ::ffff:255.255.255.255  ::ffff:0:255.255.255.255 (IPv4-mapped IPv6 addresses and IPv4-translated addresses)
+      |(?:(?:[0-9a-f]{1,4}:){1,4}:{{ipv4}})                 # 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33                       (IPv4-Embedded IPv6 Address)
+      |(?:fe80:(?::[0-9a-f]{1,4}){0,4}%[0-9a-z]{1,})        # fe80::7:8%eth0     fe80::7:8%1                                      (link-local IPv6 addresses with zone index)
+      |(?:(?:[0-9a-f]{1,4}:){7,7}    [0-9a-f]{1,4})         # 1:2:3:4:5:6:7:8
+      |   (?:[0-9a-f]{1,4}:      (?::[0-9a-f]{1,4}){1,6})   # 1::3:4:5:6:7:8     1::3:4:5:6:7:8   1::8
+      |(?:(?:[0-9a-f]{1,4}:){1,2}(?::[0-9a-f]{1,4}){1,5})   # 1::4:5:6:7:8       1:2::4:5:6:7:8   1:2::8
+      |(?:(?:[0-9a-f]{1,4}:){1,3}(?::[0-9a-f]{1,4}){1,4})   # 1::5:6:7:8         1:2:3::5:6:7:8   1:2:3::8
+      |(?:(?:[0-9a-f]{1,4}:){1,4}(?::[0-9a-f]{1,4}){1,3})   # 1::6:7:8           1:2:3:4::6:7:8   1:2:3:4::8
+      |(?:(?:[0-9a-f]{1,4}:){1,5}(?::[0-9a-f]{1,4}){1,2})   # 1::7:8             1:2:3:4:5::7:8   1:2:3:4:5::8
+      |(?:(?:[0-9a-f]{1,4}:){1,6}   :[0-9a-f]{1,4})         # 1::8               1:2:3:4:5:6::8   1:2:3:4:5:6::8
+      |(?:(?:[0-9a-f]{1,4}:){1,7}   :)                      # 1::                                 1:2:3:4:5:6:7::
+      |(?::(?:(?::[0-9a-f]{1,4}){1,7}|:))                   # ::2:3:4:5:6:7:8    ::2:3:4:5:6:7:8  ::8       ::
+    )(?![0-9A-Za-z:])
+  base64_char: '[0-9A-Za-z+/]'
+  base64_string: |-
+    (?x:
+      (?:{{base64_char}}{4})+
+      (?:{{base64_char}}{2}==|
+         {{base64_char}}{3}=)?
+    )
+  boundary_name: (?:[\w=?:-]+)
+  day3: (?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)
+  month3: (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)
+
 contexts:
   main:
+    - match: ''
+      set: header-block
+
+  header-block:
+    - meta_content_scope: meta.block.header.eml
+    - match: ^(?=\r?\n)
+      set: body-block
+
+    # Special headers
+    - match: ^((?i:From|To|Cc|Bcc|Date))(:)
+      captures:
+        1: meta.mapping.key.header.eml entity.name.label.eml
+        2: punctuation.separator.mapping.key-value.eml
+      push: header-value
+    - match: ^(Subject)(:)[ \t]*
+      captures:
+        1: meta.mapping.key.header.eml entity.name.label.eml
+        2: punctuation.separator.mapping.key-value.eml
+      push:
+        - meta_content_scope: meta.mapping.value.header.eml entity.name.class.eml
+        - match: ^(?=\S|$)
+          pop: true
+
     # Security Headers
-    - match: "(?ix)^((.*)?-Signature|Authentication-results|DomainKey-Signature|Received-SPF)(:)"
-      scope: invalid
+    - match: ^((?:\S+-)?Signature|Authentication-Results|DomainKey-Signature|Received-SPF)(:)"
+      captures:
+        1: meta.mapping.key.header.eml support.function.eml
+        2: punctuation.separator.mapping.key-value.eml
+      push: header-value
 
-    # Custom Headers
-    #   X-Mailer:
-    - match: "(?ix)^x-([a-z0-9-]+)(:)"
-      scope: storage
+    - include: generic-header-kvp
 
-    # Headers (https://en.wikipedia.org/wiki/Email#Message_header)
-    #   From:
-    #   MIME-Version:
-    - match: "(?x)^([A-Z][a-zA-Z0-9-]+)(:)"
-      scope: keyword.control
+  generic-header-kvp:
+    # https://en.wikipedia.org/wiki/Email#Message_header
+    - match: ^((?i:(x-)?[a-z0-9-]+))(:)
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: variable.annotation.eml
+        3: punctuation.separator.mapping.key-value.eml
+      push: header-value
 
-    # Email addresses
-    #   john.doe@example.com
-    #   <john.doe@example.com>
-    - match: "(?ix)((<?) [-a-z0-9.:_]+@[-a-zA-Z0-9.]+ (>?))"
-      scope: string.underline.link
+  header-value:
+    - meta_content_scope: meta.mapping.value.header.eml
+    - match: ^(?=\S|$)
+      pop: true
+    - include: common
+    - match: \b([a-zA-Z0-9-]+)\b(=)(?!\s|=)
+      captures:
+        1: variable.other.readwrite.eml
+        2: keyword.operator.assignment.eml
+      push:
+        - match: (?=[\s;,])
+          pop: true
+        - include: string-double-quote
+        - include: header-sub-values
+    - match: ;
+      scope: punctuation.separator.sequence.eml
+    - include: string-double-quote
+    - include: mime-type
+
+  header-sub-values:
+    - match: (?:\b|\B-)\d+(\.)\d+(?=[\s;"])
+      scope: constant.numeric.float.eml
+      captures:
+        1: punctuation.separator.decimal.eml
+    - match: (?:\b|\B-)\d+(?=[\s;"])
+      scope: constant.numeric.integer.eml
+    - include: common
+    - include: mime-type
+    - match: '[^\s;,]+'
+      scope: string.unquoted.eml
+
+  string-double-quote:
+    - match: '"'
+      scope: punctuation.definition.string.begin.eml
+      push:
+        - meta_scope: string.quoted.double.eml
+        - match: '"'
+          scope: punctuation.definition.string.end.eml
+          pop: true
+        - include: common
+        - include: mime-type
+
+  mime-type:
+    - match: \b(?:text|application|multipart|message|image)/\b[a-z-]+\b
+      scope: entity.name.enum.eml
+
+  body-block:
+    - meta_content_scope: meta.block.body.eml
+    - match: ^--({{boundary_name}})--$
+      scope: punctuation.terminator.eml
+      captures:
+        1: variable.language.eml
+    # Body with boundaries
+    - match: ^--({{boundary_name}})$
+      scope: punctuation.separator.sequence.eml
+      captures:
+        1: variable.language.eml
+      push: expect-body-instructions
+    # Single-block body
+    - match: ''
+      push: expect-body-instructions
+
+  expect-body-instructions:
+    - match: ^\n$
+      set: body-content
+    - include: generic-header-kvp
+
+  body-content:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
+    - include: encoded-words
+    - include: quoted-printable
+
+    # HTML
+    - match: ^\s*(?=<)
+      embed: scope:text.html.basic
+      escape: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
+
+    # Plaintext replies indented with `>>>`
+    - match: ^>{1,8}
+      scope: punctuation.section.block.begin.eml
+
+    - include: common
 
     # Content-Transfer-Encoding: base64
     #   VGhpcyB0ZXh0IGlzIGVuY29kZWQsIEl0IHNlZW1zIHdlaXJkLg==
-    - match: "(?x) ^ (?:[A-Za-z0-9+/]{4})+ (?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
-      scope: comment
+    - match: ^{{base64_string}}$\n?
+      scope: meta.block.base64.eml string.unquoted.eml
 
-    # Content-Transfer-Encoding: quoted-printable
-    - match: "(?x)=([0-9a-fA-F]{2})"
-      scope: variable.other
+  quoted-printable:
+    - match: =[0-9a-fA-F]{2}
+      scope: constant.character.escape.eml
+    - match: =\n
+      scope: punctuation.separator.continuation.eml
 
-    # Encoded-words (https://www.ietf.org/rfc/rfc2047.txt)
-    - match: '(?i)=\?(utf-8|windows-1251)\?B\\?(.*)\?='
-      scope: comment
-
-    # Timestamps (https://tools.ietf.org/html/rfc5322#section-3.3)
-    - match: '[a-zA-Z]{3},.*[+-][0-9]{4}\s(.{4}\))?'
-      scope: variable.language
-
-    # Frontiers
-    #   Content-Type: multipart/mixed; boundary=frontier
-    #   --frontier
-    #   --frontier
-    #   --frontier--
-    - match: "(?ix)boundary=(.+)"
-      scope: constant.character
-
-    - match: "(?ix)^--[a-zA-Z0-9-=_?:]+(--)?$"
-      scope: constant.character
-
-    # HTML (https://github.com/sublimehq/Packages/blob/master/HTML/HTML.sublime-syntax)
-    - match: "^\\s*(?=<)"
-      push: Packages/HTML/HTML.sublime-syntax
-      with_prototype:
-        - match: "(?<=>)\\s*$"
+  encoded-words:
+    # https://www.ietf.org/rfc/rfc2047.txt
+    # Quoted Printable
+    # =?iso-8859-1?q?this=20is=20some=20text?=
+    - match: (=\?)(?:(utf-8|windows-1251|iso-[a-z0-9-]+\b)(\?))?([qQ])(\?)
+      captures:
+        1: punctuation.definition.string.begin.eml
+        2: entity.name.enum.eml
+        3: punctuation.separator.sequence.eml
+        4: constant.language.eml
+        5: punctuation.separator.sequence.eml
+      push:
+        - match: \?=
+          scope: punctuation.definition.string.end.eml
           pop: true
-        - match: "[.@\"]"
-          pop: false
-
-    # JavaScript (https://github.com/sublimehq/Packages/blob/master/JavaScript/JavaScript.sublime-syntax)
-    - match: <script>
-      push: Packages/JavaScript/JavaScript.sublime-syntax
-      with_prototype:
-        - match: (?=</script>)
+        - match: '[ \t]'
+          scope: invalid.illegal.eml
+        - include: quoted-printable
+        # Is trailing newline illegal?
+    # Base 64
+    # =?iso-8859-1?b?PGh0bWw+CiAg?=
+    - match: (=\?)(utf-8|windows-1251|iso-[a-z0-9-]+\b)(\?)([bB])(\?)
+      captures:
+        1: punctuation.definition.string.begin.eml
+        2: entity.name.enum.eml
+        3: punctuation.separator.sequence.eml
+        4: constant.language.eml
+        5: punctuation.separator.sequence.eml
+      push:
+        - match: \?=
+          scope: punctuation.definition.string.end.eml
           pop: true
+        - match: '{{base64_string}}'
+          scope: meta.block.base64.eml string.unquoted.eml
+        - match: (?:[^\n]|{{base64_char}})
+          scope: invalid.illegal.eml
+        # Is trailing newline illegal?
+
+  common:
+    - include: ip-addresses
+    - include: email-addresses
+    - include: uris
+    - include: timestamps
+
+  timestamps:
+    # https://tools.ietf.org/html/rfc5322#section-3.3
+    - match: '{{day3}},.*[+-][0-9]{4}\s(?:.{4}\))?'
+      scope: constant.numeric.date-time.eml
+    - match: '\d{1,2} {{month3}}.*[+-][0-9]{4}\s(?:.{4}\))?'
+      scope: constant.numeric.date-time.eml
+
+  ip-addresses:
+    - match: '(\[){{ipv4}}(\])'
+      scope: constant.numeric.ip-address.v4.eml
+      captures:
+        1: punctuation.definition.constant.begin.eml
+        2: punctuation.definition.constant.end.eml
+    - match: '{{ipv4}}'
+      scope: constant.numeric.ip-address.v4.eml
+    - match: '(\[){{ipv6}}(\])'
+      scope: constant.numeric.ip-address.v6.eml
+      captures:
+        1: punctuation.definition.constant.begin.eml
+        2: punctuation.definition.constant.end.eml
+    - match: '{{ipv6}}'
+      scope: constant.numeric.ip-address.v6.eml
+
+  email-addresses:
+    # john.doe@example.com
+    # <john.doe@example.com>
+    - match: '(<?)mailto:'
+      captures:
+        1: punctuation.definition.string.begin.eml
+      push:
+        - meta_content_scope: markup.underline.link.email.eml
+        - match: (>?)(?=[^\w.@-])
+          captures:
+            1: punctuation.definition.string.end.eml
+          pop: true
+    - match: (<?)((?i:[-a-z0-9._+]+@[-a-z0-9.]+))(>?)
+      captures:
+        1: punctuation.definition.string.begin.eml
+        2: markup.underline.link.email.eml
+        3: punctuation.definition.string.end.eml
+
+  uris:
+    # https://example.com
+    # <https://example.com>
+    - match: (<?)(https?:)
+      captures:
+        1: punctuation.definition.string.begin.eml
+        2: markup.underline.link.url.eml
+      push:
+        - meta_content_scope: markup.underline.link.url.eml
+        - match: (>?)(?=\s)
+          captures:
+            1: punctuation.definition.string.end.eml
+          pop: true
+
+  pop-before-boundary:
+    - match: (?=^--({{boundary_name}})(?:--)?$)
+      pop: true

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -364,6 +364,10 @@ contexts:
       captures:
         1: punctuation.separator.sequence.eml
       push: maybe-timestamp-day
+    # This one is a little hinky because it attempts to find a timestamp
+    #   when there is a 0-31 number as the last text on a line. Until ST4,
+    #   we don't have the ability to backtrack when the timestamp doesn't
+    #   continue on the next line.
     - match: \b(?=(?:0?[1-9]|[12]\d|3[01])(?:\s{{month3}}|\s?=?$))
       push: maybe-timestamp-day
 

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -33,7 +33,7 @@ variables:
       (?:{{base64_char}}{2}==|
          {{base64_char}}{3}=)?
     )
-  boundary_name: (?:[\w=?:-]+)
+  boundary_name: (?:[\w=?:-]*[a-zA-Z0-9][\w=?:-]*)
   day3: (?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)
   month3: (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)
 

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -197,6 +197,12 @@ contexts:
   expect-body-instructions-base64:
     - match: ^\n$
       set: body-content-base64
+    - match: ^((?i:Content-Type))(:)\s(image/\w+)\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+        3: entity.name.enum.eml
+      set: [expect-body-instructions-image, header-value]
     - include: generic-header-kvp
 
   expect-body-instructions-image:

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -144,18 +144,79 @@ contexts:
 
   expect-body-instructions:
     - match: ^\n$
-      set: body-content
+      set: body-content-default
     - match: ^((?i:Content-Type))(:)\s(image/\w+)\b
       captures:
         1: meta.mapping.key.header.eml keyword.other.eml
         2: punctuation.separator.mapping.key-value.eml
         3: entity.name.enum.eml
       set: [expect-body-instructions-image, header-value]
+    - match: ^((?i:Content-Type))(:)\s(message/[\w-]+)\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+        3: entity.name.enum.eml
+      set: [expect-body-instructions-headers, header-value]
+    - match: ^((?i:Content-Type))(:)\s(text/(?:watch-)?html)\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+        3: entity.name.enum.eml
+      set: [expect-body-instructions-html-noencoding, header-value]
+    - match: ^((?i:Content-Transfer-Encoding))(:)\squoted-printable\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+      set: [expect-body-instructions-quoted-printable, header-value]
+    - include: become-expect-base64
+    - include: generic-header-kvp
+
+  become-expect-base64:
+    - match: ^((?i:Content-Transfer-Encoding))(:)\sbase64\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+      set: [expect-body-instructions-base64, header-value]
+
+  expect-body-instructions-base64:
+    - match: ^\n$
+      set: body-content-base64
     - include: generic-header-kvp
 
   expect-body-instructions-image:
     - match: ^\n$
       set: body-content-image
+    - include: generic-header-kvp
+
+  expect-body-instructions-headers:
+    - match: ^\n$
+      set: body-content-headers
+    - include: generic-header-kvp
+
+  expect-body-instructions-html-noencoding:
+    - match: ^\n$
+      set: body-content-html
+    - include: become-expect-base64
+    - match: ^((?i:Content-Transfer-Encoding))(:)\squoted-printable\b
+      captures:
+        1: meta.mapping.key.header.eml keyword.other.eml
+        2: punctuation.separator.mapping.key-value.eml
+      set: [expect-body-instructions-html-quoted-printable, header-value]
+    - include: generic-header-kvp
+
+  expect-body-instructions-quoted-printable:
+    - match: ^\n$
+      set: body-content-quoted-printable
+    - include: generic-header-kvp
+
+  expect-body-instructions-html-quoted-printable:
+    - match: ^\n$
+      set: body-content-html-quoted-printable
+    - include: generic-header-kvp
+
+  body-content-headers:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
     - include: generic-header-kvp
 
   body-content-image:
@@ -164,27 +225,61 @@ contexts:
     - match: ^{{base64_string}}$\n?
       scope: meta.block.base64.image.eml string.unquoted.eml
 
-  body-content:
+  body-content-html:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
+    - match: ''
+      embed: scope:text.html.basic
+      escape: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
+
+  body-content-html-quoted-printable:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
+    - match: ''
+      push: scope:text.html.basic
+      with_prototype:
+        - match: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
+          pop: true
+        - match: \b=3[dD](?=['"])
+          scope: constant.character.escape.eml
+          push:
+            - scope:text.html.basic#tag-generic-attribute-value
+        - include: quoted-printable
+
+  body-content-quoted-printable:
     - meta_content_scope: meta.region.body.email
     - include: pop-before-boundary
     - include: encoded-words
     - include: quoted-printable
-
-    # HTML
-    - match: ^\s*(?=<)
-      embed: scope:text.html.basic
-      escape: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
-
-    # Plaintext replies indented with `>>>`
-    - match: ^>{1,8}
-      scope: punctuation.section.block.begin.eml
-
+    - include: plaintext-blockquote
     - include: common
 
+  body-content-default:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
+    - include: encoded-words
+    - include: plaintext-blockquote
+    - include: common
+    # Including Base64 here is a hack to avoid scanning the
+    #   real headers for type and encoding information. It's
+    #   lots easier to assume all messages are multipart.
+    - include: base64-line
+
+  body-content-base64:
+    - meta_content_scope: meta.region.body.email
+    - include: pop-before-boundary
+    - include: base64-line
+
+  base64-line:
     # Content-Transfer-Encoding: base64
     #   VGhpcyB0ZXh0IGlzIGVuY29kZWQsIEl0IHNlZW1zIHdlaXJkLg==
     - match: ^{{base64_string}}$\n?
       scope: meta.block.base64.eml string.unquoted.eml
+
+  plaintext-blockquote:
+    # Plaintext replies indented with `>>>`
+    - match: ^>{1,8}
+      scope: punctuation.section.block.begin.eml
 
   quoted-printable:
     - match: =[0-9a-fA-F]{2}

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -239,35 +239,38 @@ contexts:
   timestamps:
     # https://tools.ietf.org/html/rfc5322#section-3.3
     - match: \b{{day3}}(,)(?=\s\d{1,2}|$)
+      scope: constant.numeric.date-time.eml
       captures:
         1: punctuation.separator.sequence.eml
-      set: maybe-timestamp-day
-    - match: \b(?=(?:[1-9]|[12]\d|3[01])(?:\s{{month3}}|$))
-      set: maybe-timestamp-day
+      push: maybe-timestamp-day
+    - match: \b(?=(?:[1-9]|[12]\d|3[01])(?:\s{{month3}}|\s?=?$))
+      push: maybe-timestamp-day
+
+  ignore-qp-newline-pop-nonws:
+    - match: =$
+    - match: (?=\S)
+      pop: true
 
   maybe-timestamp-day:
-    - meta_scope: constant.numeric.date-time.eml
-    - match: \b(?:[1-9]|[12]\d|3[01])(?=\s{{month3}}|$)
+    - meta_content_scope: constant.numeric.date-time.eml
+    - match: \b(?:[1-9]|[12]\d|3[01])(?=\s{{month3}}|\s?=?$)
       set: in-timestamp-month
-    - match: (?=\S)
-      pop: true
+    - include: ignore-qp-newline-pop-nonws
 
   in-timestamp-month:
-    - meta_scope: constant.numeric.date-time.eml
+    - meta_content_scope: constant.numeric.date-time.eml
     - match: \b{{month3}}\b
       set: in-timestamp-year
-    - match: (?=\S)
-      pop: true
+    - include: ignore-qp-newline-pop-nonws
 
   in-timestamp-year:
-    - meta_scope: constant.numeric.date-time.eml
+    - meta_content_scope: constant.numeric.date-time.eml
     - match: \b(?:19\d{2}|20\d{2})\b
       set: in-timestamp-time-of-day
-    - match: (?=\S)
-      pop: true
+    - include: ignore-qp-newline-pop-nonws
 
   in-timestamp-time-of-day:
-    - meta_scope: constant.numeric.date-time.eml
+    - meta_content_scope: constant.numeric.date-time.eml
     - match: |-
         (?x:
           (?:[01]\d|2[0-3])  # hour
@@ -278,7 +281,7 @@ contexts:
             (?:[0-5]\d)      # second (optional)
             (?:
               (\.)
-              \d{1,4}        # fractional second (not RFC5322)
+              \d{1,4}        # fractional second (not rfc5322)
             )?
           )?
         )
@@ -287,17 +290,16 @@ contexts:
         2: punctuation.separator.sequence.eml
         3: punctuation.separator.decimal.eml
       set: in-timestamp-zone
-    - match: (?=\S)
-      pop: true
+    - include: ignore-qp-newline-pop-nonws
 
   in-timestamp-zone:
-    - meta_scope: constant.numeric.date-time.eml
+    - meta_content_scope: constant.numeric.date-time.eml
     - match: ([+-])(?:0\d{3}|1[0-2]\d{2})
+      scope: constant.numeric.date-time.eml
       captures:
         1: keyword.operator.arithmetic.eml
       pop: true
-    - match: (?=\S)
-      pop: true
+    - include: ignore-qp-newline-pop-nonws
 
   ip-addresses:
     - match: '(\[){{ipv4}}(\])'

--- a/email.sublime-syntax
+++ b/email.sublime-syntax
@@ -289,9 +289,15 @@ contexts:
     - include: encoded-words
     - include: plaintext-blockquote
     - include: common
-    # Including Base64 here is a hack to avoid scanning the
-    #   real headers for type and encoding information. It's
-    #   lots easier to assume all messages are multipart.
+
+    # Hacks to avoid toggling state while scanning message headers.
+    #   It's easier to assume `multipart/*`.
+    - match: ^(?=<\?xml\b)
+      embed: scope:text.xml
+      escape: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
+    - match: ^(?=(?:<html|<!DOCTYPE html)\b)
+      embed: scope:text.html.basic
+      escape: ^(?=--[a-zA-Z0-9-=_?:]+(--)?$)
     - include: base64-line
 
   body-content-base64:
@@ -329,6 +335,7 @@ contexts:
 
   encoded-words:
     # https://www.ietf.org/rfc/rfc2047.txt
+
     # Quoted Printable
     # =?iso-8859-1?q?this=20is=20some=20text?=
     - match: (=\?)(?:(utf-8|windows-1251|iso-[a-z0-9-]+\b)(\?))?([qQ])(\?)
@@ -346,6 +353,7 @@ contexts:
           scope: invalid.illegal.eml
         - include: quoted-printable
         # Is trailing newline illegal?
+
     # Base 64
     # =?iso-8859-1?b?PGh0bWw+CiAg?=
     - match: (=\?)(utf-8|windows-1251|iso-[a-z0-9-]+\b)(\?)([bB])(\?)

--- a/support.py
+++ b/support.py
@@ -1,0 +1,53 @@
+import sublime
+import sublime_plugin
+
+from base64 import b64decode
+import html
+
+
+class EmailViewListener(sublime_plugin.ViewEventListener):
+
+    SYNTAX = 'email.sublime-syntax'
+
+    @classmethod
+    def is_applicable(cls, settings):
+        try:
+            return (settings and
+                    settings.get('syntax', '').lower().endswith(cls.SYNTAX))
+        except Exception as e:
+            return False
+
+    def format_hover_line(self, text):
+        text = text.replace('  ', ' &nbsp;').replace('\t', '&nbsp;' * 4)
+        return '<div>{}&nbsp;</div>'.format(text)
+
+    def on_hover(self, point, hover_zone):
+        if ((hover_zone != sublime.HOVER_TEXT or not
+             self.view.match_selector(point, 'meta.block.base64'))):
+            return
+
+        expression_region = next(
+            r for r in self.view.find_by_selector('meta.block.base64')
+            if r.contains(point))
+
+        base64_text = self.view.substr(expression_region)
+
+        try:
+            hover_text = b64decode(str.encode(base64_text)).decode()
+            hover_lines = html.escape(hover_text).split('\n')[:50]
+            hover_text = '\n'.join(self.format_hover_line(line)
+                                   for line in hover_lines)
+            # TODO: Add link to decode whole block in new `view`.
+        except Exception as e:
+            hover_text = 'Could not decode Base 64 to text'
+
+        html_text = '''
+            <body style="width: 500px;">
+                <div id="render-base64">
+                    {}
+                </div>
+            </body>
+        '''.format(hover_text)
+
+        self.view.show_popup(html_text, sublime.HIDE_ON_MOUSE_MOVE_AWAY,
+                             location=point,)

--- a/support.py
+++ b/support.py
@@ -26,20 +26,26 @@ class EmailViewListener(sublime_plugin.ViewEventListener):
              self.view.match_selector(point, 'meta.block.base64'))):
             return
 
+        is_image = self.view.match_selector(point, 'meta.block.base64.image')
+
         expression_region = next(
             r for r in self.view.find_by_selector('meta.block.base64')
             if r.contains(point))
 
         base64_text = self.view.substr(expression_region)
 
-        try:
-            hover_text = b64decode(str.encode(base64_text)).decode()
-            hover_lines = html.escape(hover_text).split('\n')[:50]
-            hover_text = '\n'.join(self.format_hover_line(line)
-                                   for line in hover_lines)
-            # TODO: Add link to decode whole block in new `view`.
-        except Exception as e:
-            hover_text = 'Could not decode Base 64 to text'
+        if is_image:
+            hover_text = '<img src="data:image/jpeg;base64, {}" />'.format(
+                base64_text)
+        else:
+            try:
+                hover_text = b64decode(str.encode(base64_text)).decode()
+                hover_lines = html.escape(hover_text).split('\n')[:50]
+                hover_text = '\n'.join(self.format_hover_line(line)
+                                       for line in hover_lines)
+                # TODO: Add link to decode whole block in new `view`.
+            except Exception as e:
+                hover_text = 'Could not decode Base 64 to text'
 
         html_text = '''
             <body style="width: 500px;">

--- a/support.py
+++ b/support.py
@@ -37,6 +37,7 @@ class EmailViewListener(sublime_plugin.ViewEventListener):
         if is_image:
             hover_text = '<img src="data:image/jpeg;base64, {}" />'.format(
                 base64_text)
+            # TODO: Add link to export image.
         else:
             try:
                 hover_text = b64decode(str.encode(base64_text)).decode()

--- a/support.py
+++ b/support.py
@@ -1,8 +1,11 @@
 import sublime
 import sublime_plugin
 
-from base64 import b64decode
 import html
+import re
+from base64 import b64decode
+from datetime import timezone
+from email.utils import parsedate_to_datetime
 
 
 class EmailViewListener(sublime_plugin.ViewEventListener):
@@ -17,21 +20,15 @@ class EmailViewListener(sublime_plugin.ViewEventListener):
         except Exception as e:
             return False
 
-    def format_hover_line(self, text):
-        text = text.replace('  ', ' &nbsp;').replace('\t', '&nbsp;' * 4)
-        return '<div>{}&nbsp;</div>'.format(text)
-
-    def on_hover(self, point, hover_zone):
-        if ((hover_zone != sublime.HOVER_TEXT or not
-             self.view.match_selector(point, 'meta.block.base64'))):
-            return
-
-        is_image = self.view.match_selector(point, 'meta.block.base64.image')
-
-        expression_region = next(
-            r for r in self.view.find_by_selector('meta.block.base64')
+    def _pt2rgn_by_scope(self, point, scope):
+        return next(
+            r for r in self.view.find_by_selector(scope)
             if r.contains(point))
 
+    def hover_base64(self, point):
+        is_image = self.view.match_selector(point, 'meta.block.base64.image')
+
+        expression_region = self._pt2rgn_by_scope(point, 'meta.block.base64')
         base64_text = self.view.substr(expression_region)
 
         if is_image:
@@ -47,12 +44,56 @@ class EmailViewListener(sublime_plugin.ViewEventListener):
                 # TODO: Add link to decode whole block in new `view`.
             except Exception as e:
                 hover_text = 'Could not decode Base 64 to text'
+        return '''
+            <div id="render-base64">
+                {}
+            </div>
+        '''.format(hover_text)
+
+    def hover_datetime(self, point):
+        expression_region = self._pt2rgn_by_scope(
+            point, 'constant.numeric.date-time')
+        date_str = re.sub(r'\s=?\s*', ' ', self.view.substr(expression_region))
+        try:
+            date = parsedate_to_datetime(date_str)
+        except Exception as e:
+            return 'Could not parse date'
+        return '''
+            <b style="color: var(--bluish);">Local Time</b>
+            <div>{local:%c}</div>
+            <div>{local}</div>
+            <b style="color: var(--bluish);">UTC Time</b>
+            <div>{utc:%c}</div>
+            <div>{utc}</div>
+        '''.format(
+            local=date.astimezone(),
+            utc=date.astimezone(timezone.utc),
+        )
+
+    def format_hover_line(self, text):
+        text = text.replace('  ', ' &nbsp;').replace('\t', '&nbsp;' * 4)
+        return '<div>{}&nbsp;</div>'.format(text)
+
+    def on_hover(self, point, hover_zone):
+
+        hover_scopes = {
+            'meta.block.base64': self.hover_base64,
+            'constant.numeric.date-time': self.hover_datetime,
+        }
+
+        if ((hover_zone != sublime.HOVER_TEXT or not self.view.match_selector(
+                point, ','.join(k for k in hover_scopes)))):
+            return
+
+        # Run the function for the first matching scope
+        for scope, method in hover_scopes.items():
+            if self.view.match_selector(point, scope):
+                hover_text = method(point)
+                break
 
         html_text = '''
-            <body style="width: 500px;">
-                <div id="render-base64">
-                    {}
-                </div>
+            <body>
+                {}
             </body>
         '''.format(hover_text)
 

--- a/support/body region.tmPreferences
+++ b/support/body region.tmPreferences
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Symbol List</string>
+    <key>scope</key>
+    <string>
+        text.eml meta.region.body
+    </string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string>
+        s/(.+)/Body region/g;
+        </string>
+    </dict>
+</dict>
+</plist>

--- a/support/headers.tmPreferences
+++ b/support/headers.tmPreferences
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Symbol List</string>
+    <key>scope</key>
+    <string>
+        text.eml meta.mapping.key.header
+    </string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string>
+        s/(.+)/Header: $1/g;
+        </string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Hi @mariozaizar. I learned some things since my first attempts in 2015-2017 at [michaelblyons/SublimeSyntax-Email](https://github.com/michaelblyons/SublimeSyntax-Email). I hope they are welcome here.

This PR:
- [x] Navigate to headers and body sections (<kbd>Cmd</kbd>+<kbd>R</kbd>).
    + This context awareness will also be helpful for future improvements.
- [x] Highlighting within headers.
- [x] Closer to suggested scope documentation.
- [x] Hover preview for Base64 text.
- [x] Hover preview for Base64 images.
- [x] Hovering over datetimes shows the timestamp in your local time and in UTC.
- [x] Highlight Base64 and Quoted-Printable __only__ if the header says to
    + Some exceptions apply.
- [x] Highlight HTML __only__ if the header says to
    + Some exceptions apply.
- [x] `prototype` Quoted Printable into HTML where appropriate.
- [x] Allowances for `Content-transfer-encoding` appearing before `Content-type`.
   + This is done for some cases but not all of them.

Maybe future:
- [ ] Regression tests.
